### PR TITLE
Document governor alert workflows

### DIFF
--- a/.github/actions/bootstrap/action.yml
+++ b/.github/actions/bootstrap/action.yml
@@ -23,5 +23,5 @@ runs:
       uses: foundry-rs/foundry-toolchain@8789b3e21e6c11b2697f5eb56eddae542f746c10 # v1.7.0
 
     - name: Install dependencies
-      run: pnpm install --frozen-lockfile
+      run: pnpm install
       shell: bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,11 +8,23 @@ This repository monitors governor and voting events and forwards alert notificat
 
 - Node.js must use version 22+.
 - Use `.nvmrc` and `.node-version` files for version alignment.
-- Run `pnpm install --frozen-lockfile` before dependency-dependent work.
+- Run `pnpm install` before dependency-dependent work.
+- If `pnpm` is unavailable after `nvm use`, use `corepack pnpm ...`.
+- pnpm policy lives in `pnpm-workspace.yaml`, not `.npmrc`. Keep dependency overrides, `minimumReleaseAge`, `preferFrozenLockfile`, and `nodeLinker: hoisted` there unless a tool specifically requires another location.
 
 ## Common Commands
 
-- `pnpm install --frozen-lockfile`: install dependencies
-- `pnpm run lint` or repository lint equivalent: run project lint checks
-- `pnpm run build` or repository build equivalent: validate builds succeed
-- `pnpm test` or repository test equivalent: validate behavior changes
+- `pnpm install`: install dependencies using the lockfile policy from `pnpm-workspace.yaml`
+- `pnpm run build`: build the Cloud Function TypeScript
+- `pnpm run lint`: run Prettier and ESLint fixes in `function/`
+- `pnpm run lint:check`: run the non-mutating ESLint check in `function/`
+- `pnpm test`: run Jest tests in `function/`
+- `pnpm run codegen`: regenerate GraphQL types from the function GraphQL documents
+
+## Deployment
+
+- Use Pulumi for deployments: `pulumi preview --stack <dev|prod>` before `pulumi up --stack <dev|prod>`.
+- The `dev` stack targets GCP project `governor-discord-alerts-dev`; the `prod` stack targets `governor-discord-alerts`.
+- The Pulumi program provisions the GCS buckets, Cloud Function, Cloud Scheduler job, invoker IAM binding, and monitoring alert policy.
+- Required Pulumi stack secrets are `discordWebhookUrl`, `notificationEmail`, and `subgraphApiKey`.
+- The Cloud Function uses `gcp.cloudfunctions.Function` v1 and must stay pinned to runtime `nodejs22` until that resource supports a newer runtime.

--- a/README.md
+++ b/README.md
@@ -13,29 +13,67 @@ It performs the following steps:
 
 ## Setup
 
+1. Use Node.js 22:
+
+   ```bash
+   nvm use
+   ```
+
 1. Install dependencies:
 
    ```bash
    pnpm install
    ```
 
+   If `pnpm` is not on your PATH after `nvm use`, use Corepack directly:
+
+   ```bash
+   corepack pnpm install
+   ```
+
 1. Copy `.env.example` to `.env` and set the variables.
+
+## Common Tasks
+
+- `pnpm install`: install dependencies using the lockfile policy from `pnpm-workspace.yaml`.
+- `pnpm run build`: build the Cloud Function TypeScript.
+- `pnpm run lint`: run Prettier and ESLint fixes in `function/`.
+- `pnpm run lint:check`: run the non-mutating ESLint check in `function/`.
+- `pnpm test`: run the Jest test suite in `function/`.
+- `pnpm run codegen`: regenerate GraphQL types from `function/src/proposals.graphql`.
 
 ## Deployment
 
-1. Build the function:
+Deployments are managed with Pulumi stacks:
+
+- `dev`: GCP project `governor-discord-alerts-dev`
+- `prod`: GCP project `governor-discord-alerts`
+
+1. Build and test the function:
 
    ```bash
    pnpm run build
+   pnpm test
    ```
 
-1. Deploy the function:
+1. Preview the deployment:
+
+   ```bash
+   pulumi preview --stack <dev|prod>
+   ```
+
+1. Apply the deployment:
 
    ```bash
    pulumi up --stack <dev|prod>
    ```
 
-   Note: the project uses `gcp.cloudfunctions.Function` (Cloud Functions v1), which currently does not support Node.js 24 runtimes.
-   The function runtime is therefore pinned to `nodejs22`.
+The Pulumi program creates the GCS buckets, Cloud Function, Cloud Scheduler job, invoker IAM binding, and monitoring alert policy. Stack secrets provide `discordWebhookUrl`, `notificationEmail`, and `subgraphApiKey`.
 
-Pulumi may require pnpm's hoisted linker layout to avoid `.pnpm/...` closure-loading or export-path errors, so this repo sets `node-linker=hoisted` in `.npmrc`.
+Note: the project uses `gcp.cloudfunctions.Function` (Cloud Functions v1), which currently does not support Node.js 24 runtimes. The function runtime is therefore pinned to `nodejs22`.
+
+Pulumi may require pnpm's hoisted linker layout to avoid `.pnpm/...` closure-loading or export-path errors, so this repo sets `nodeLinker: hoisted` in `pnpm-workspace.yaml`.
+
+## pnpm Policy
+
+This repo stores pnpm policy in `pnpm-workspace.yaml`, including dependency overrides, `minimumReleaseAge`, `preferFrozenLockfile`, and the hoisted linker layout. The repository intentionally does not use `.npmrc` for these pnpm-only settings.

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "codegen": "cd function && dotenv -e ../.env -- node_modules/.bin/graphql-codegen",
     "lint": "cd function && pnpm run lint",
     "lint:check": "cd function && pnpm run lint:check",
-    "test": "cd function && pnpm run test",
-    "preinstall": "npx only-allow@1.2.2 pnpm"
+    "test": "cd function && pnpm run test"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary

- Documents setup, common repository tasks, and Pulumi deployment workflow for governor Discord alerts.
- Clarifies that pnpm policy lives in `pnpm-workspace.yaml`, including the hoisted linker and lockfile behavior.
- Removes the `npx only-allow` preinstall hook so `pnpm install` no longer invokes npm and emits pnpm config warnings.
- Updates the CI bootstrap install command to rely on workspace pnpm policy instead of passing `--frozen-lockfile` explicitly.

## Validation

- `pnpm install`
- `pnpm run lint`
- `pnpm run lint:check`
- `pnpm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup guidance requiring Node.js 22+ and clarified pnpm installation instructions
  * Expanded deployment documentation with Pulumi stack configuration (dev/prod), required secrets, and Cloud Function runtime pinning
  * Documented common tasks and commands for build, lint, test, and codegen operations

* **Chores**
  * Modified CI dependency installation to allow lockfile updates
  * Reorganized build scripts in configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OlympusDAO/governor-discord-alerts/pull/5?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->